### PR TITLE
Fixed Group details page events count update

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -86,7 +86,10 @@ interface Group extends BaseSchema {
   admin: Pick<User, "id" | "name" | "profilePhoto">;
   poster?: string | null;
   category: Pick<Category, "id" | "name" | "slug">;
-  _count: Pick<_Count, "members">;
+  _count: {
+    members: number;
+    events: number;
+  };
   network?: Pick<Network, "id" | "name">;
 }
 

--- a/src/routes/(public)/[slug]/layout.tsx
+++ b/src/routes/(public)/[slug]/layout.tsx
@@ -105,7 +105,7 @@ export default component$(() => {
               </div>
               <div class="flex items-center gap-3 text-muted-foreground">
                 <LuCalendarCheck class="mr-1 h-5 w-5" />
-                <span>{groupSig.value?._count.members} events</span>
+                <span>{groupSig.value?._count.events} events</span>
               </div>
             </div>
             <div class="mt-6 flex flex-wrap gap-3">


### PR DESCRIPTION
Closes #77 

I have fixed the issue where clicking the 'Join the Group' button was updating the events count. It should only update the members count, and now it updates only the members count as intended.