### PR TITLE
Added width and height in logo image for optimised import of images 

### DIFF
--- a/src/components/shared/logo.tsx
+++ b/src/components/shared/logo.tsx
@@ -1,11 +1,11 @@
 import { component$ } from "@builder.io/qwik";
 import { Link } from "@builder.io/qwik-city";
 import { SITE_NAME } from "~/lib/constatnts";
+import LogoSrc from "/logo.svg";
 
 export const Logo = component$(() => (
   <Link href="/">
     {/* <h1 class="text-2xl font-extrabold italic text-alert">{SITE_NAME}</h1> */}
-    <img src="/logo.svg" alt={SITE_NAME} class="w-36" />
+    <img src={LogoSrc} alt={SITE_NAME} width="200" height="200" />
   </Link>
-
 ));

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -86,7 +86,10 @@ interface Group extends BaseSchema {
   admin: Pick<User, "id" | "name" | "profilePhoto">;
   poster?: string | null;
   category: Pick<Category, "id" | "name" | "slug">;
-  _count: Pick<_Count, "members">;
+  _count: {
+    members: number;
+    events: number;
+  };
   network?: Pick<Network, "id" | "name">;
 }
 

--- a/src/routes/(public)/[slug]/layout.tsx
+++ b/src/routes/(public)/[slug]/layout.tsx
@@ -105,7 +105,7 @@ export default component$(() => {
               </div>
               <div class="flex items-center gap-3 text-muted-foreground">
                 <LuCalendarCheck class="mr-1 h-5 w-5" />
-                <span>{groupSig.value?._count.members} events</span>
+                <span>{groupSig.value?._count.events} events</span>
               </div>
             </div>
             <div class="mt-6 flex flex-wrap gap-3">


### PR DESCRIPTION
Closes #76 
### Description
This PR fixes the issue where the logo image does not have defined width and height attributes. This omission negatively impacts web performance and can cause layout shifts , 

