### PR TITLE
feat: add menu links in account page sidebar

### DIFF
--- a/src/routes/(authenticated)/account/sidebar.tsx
+++ b/src/routes/(authenticated)/account/sidebar.tsx
@@ -7,15 +7,43 @@ export const Sidebar = component$(() => {
       name: "Edit profile",
       href: "/",
     },
+    {
+      name: "Personal Info",
+      href: "/",
+    },
+    {
+      name: "Account Management",
+      href: "/",
+    },
+    {
+      name: "Email Updates",
+      href: "/",
+    },
+    {
+      name: "Privacy",
+      href: "/",
+    },
+    {
+      name: "Social Media",
+      href: "/",
+    },
+    {
+      name: "Interests",
+      href: "/",
+    },
+    {
+      name: "Help",
+      href: "/",
+    },
   ];
   return (
     <aside class="w-full flex-none overflow-y-auto bg-muted md:w-[250px]">
       <h2 class="mt-4 px-4 text-lg font-bold">Settings</h2>
       <ul class="my-2">
-        {[...new Array(20)].map((i) => (
-          <li class="px-4 py-2" key={i}>
-            <Link href="" class="text-sm opacity-80">
-              Edit Profile
+        {menus.map((menu, index) => (
+          <li class="px-4 py-2" key={index}>
+            <Link href={menu.href} class="text-sm opacity-80">
+              {menu.name}
             </Link>
           </li>
         ))}


### PR DESCRIPTION
Closes #35 

I added the links as instructed. Right now they all redirect to "/"
If you need changes, let me know.

Screenshot:
![screenshot](https://github.com/user-attachments/assets/b8d504f3-9b33-4a83-a7fa-9443f7608ba2)
